### PR TITLE
Better Image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Designed to make using the Notion SDK and API easier.  Notion API version 0.4.5.
 * All headers (header levels >= 3 are treated as header level 3)
 * Code blocks
 * Block quotes
-* Images (where the image is the first element in the paragraph and it has a valid full URL)
+* Images
+  - Inline images are extracted from the paragraph and added afterwards (as these are not supported in notion)
+  - Image urls are validated, if they are not valid as per the Notion external spec, they will be inserted as text for you to fix manually 
 
 ## Unsupported Markdown Elements
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Designed to make using the Notion SDK and API easier.  Notion API version 0.4.5.
 * Block quotes
 * Images
   - Inline images are extracted from the paragraph and added afterwards (as these are not supported in notion)
-  - Image urls are validated, if they are not valid as per the Notion external spec, they will be inserted as text for you to fix manually 
+  - Image urls are validated, if they are not valid as per the Notion external spec, they will be inserted as text for you to fix manually
+  - Embed images are allowed on specific domains via options.embedUrls. These images are inserted as embed block.
 
 ## Usage
 
@@ -54,7 +55,7 @@ const richText: RichText[] = markdownToRichText(`**Hello _world_**`);
 //   }
 // ]
 
-const options = { allowUnsupportedObjectType: false, strictImageUrls: true };
+const options = { allowUnsupportedObjectType: false, strictImageUrls: true, embedUrls: ['googleusercontent.com'] };
 const blocks: Block[] = markdownToBlocks(`
 ## this is a _heading 2_
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@instantish/martian",
+  "name": "@tryfabric/martian",
   "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@instantish/martian",
+      "name": "@tryfabric/martian",
       "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
-        "@notionhq/client": "^0.4.4",
+        "@notionhq/client": "^0.4.5",
         "remark-gfm": "^1.0.0",
         "remark-parse": "^9.0.0",
         "unified": "^9.2.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gfm"
   ],
   "engines": {
-    "node": ">=15"
+    "node": ">=14"
   },
   "author": "Richard Robinson",
   "license": "ISC",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import {parseBlocks, parseRichText} from './parser/internal';
 import type * as md from './markdown';
 import gfm from 'remark-gfm';
 
+export interface ParserOptions {
+  allowUnsupportedObjectType?: boolean;
+  strictImageUrls?: boolean;
+}
+
 /**
  * Parses Markdown content into Notion Blocks.
  * - Supports all heading types (heading depths 4, 5, 6 are treated as 3 for Notion)
@@ -24,10 +29,15 @@ import gfm from 'remark-gfm';
  */
 export function markdownToBlocks(
   body: string,
-  allowUnsupportedObjectType = false
+  options?: ParserOptions
 ): notion.Block[] {
+  const defaultedOptions = {
+    allowUnsupportedObjectType: false,
+    strictImageUrls: true,
+    ...options,
+  };
   const root = unified().use(markdown).use(gfm).parse(body);
-  return parseBlocks(root as unknown as md.Root, allowUnsupportedObjectType);
+  return parseBlocks(root as unknown as md.Root, defaultedOptions);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import type * as md from './markdown';
 import gfm from 'remark-gfm';
 
 export interface ParserOptions {
+  embedUrls?: string[];
   allowUnsupportedObjectType?: boolean;
   strictImageUrls?: boolean;
 }

--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -68,6 +68,16 @@ export function image(url: string): Block {
   } as Block;
 }
 
+export function embed(url: string): Block {
+  return {
+    object: 'block',
+    type: 'embed',
+    embed: {
+      url: url,
+    },
+  } as Block;
+}
+
 export function table_of_contents(): Block {
   return {
     object: 'block',

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -62,10 +62,7 @@ function parseImage(image: md.Image): notion.Block {
     '.heic',
   ];
 
-  function dealWithError() {
-    console.log(
-      `${image.url} is not a valid Notion image url, I will process this as text for you to fix later`
-    );
+  function dealWithError() {    
     return notion.paragraph([notion.richText(image.url)]);
   }
 

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -3,6 +3,7 @@ import * as notion from '../notion';
 import {ParserOptions} from '..';
 import path from 'path';
 import {URL} from 'url';
+import {embed} from '../notion';
 
 function ensureLength(text: string, copy?: object) {
   const chunks = text.match(/[^]{1,2000}/g) || [];
@@ -77,6 +78,18 @@ function parseImage(image: md.Image, options: ParserOptions): notion.Block {
         return dealWithError();
       }
     } else {
+      if (options.embedUrls && options.embedUrls.length) {
+        const re = new RegExp(
+          `^https?://(?:[^/@:]*:[^/@]*@)?(?:[^/:]+.)?(${options.embedUrls.join(
+            '|'
+          )})(?=[/:]|$)`,
+          'i'
+        );
+        if (re.test(image.url)) {
+          return notion.embed(image.url);
+        }
+      }
+
       return notion.image(image.url);
     }
   } catch (error: unknown) {

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -69,6 +69,18 @@ function parseImage(image: md.Image, options: ParserOptions): notion.Block {
   }
 
   try {
+    if (options.embedUrls && options.embedUrls.length) {
+      const re = new RegExp(
+        `^https?://(?:[^/@:]*:[^/@]*@)?(?:[^/:]+.)?(${options.embedUrls.join(
+          '|'
+        )})(?=[/:]|$)`,
+        'i'
+      );
+      if (re.test(image.url)) {
+        return notion.embed(image.url);
+      }
+    }
+
     if (options.strictImageUrls) {
       const parsedUrl = new URL(image.url);
       const fileType = path.extname(parsedUrl.pathname);
@@ -78,18 +90,6 @@ function parseImage(image: md.Image, options: ParserOptions): notion.Block {
         return dealWithError();
       }
     } else {
-      if (options.embedUrls && options.embedUrls.length) {
-        const re = new RegExp(
-          `^https?://(?:[^/@:]*:[^/@]*@)?(?:[^/:]+.)?(${options.embedUrls.join(
-            '|'
-          )})(?=[/:]|$)`,
-          'i'
-        );
-        if (re.test(image.url)) {
-          return notion.embed(image.url);
-        }
-      }
-
       return notion.image(image.url);
     }
   } catch (error: unknown) {

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -64,7 +64,7 @@ function parseImage(image: md.Image, options: ParserOptions): notion.Block {
   ];
 
   function dealWithError() {
-    return notion.paragraph([notion.richText(image.url)]);
+    return notion.paragraph([notion.richText(image.url, {url: image.url})]);
   }
 
   try {

--- a/test/fixtures/images.md
+++ b/test/fixtures/images.md
@@ -1,6 +1,7 @@
-# Table
+# Images
 
-| First Header  | Second Header |
-| ------------- | ------------- |
-| Content Cell  | Content Cell  |
-| Content Cell  | Content Cell  |
+This is an image in a paragraph ![image-test](https://image.com/url.jpg), which isnt supported in Notion.
+
+![image-paragraph](https://image.com/paragraph.jpg)
+
+![image-invalid](https://image.com/blah)

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -114,6 +114,24 @@ const hello = "hello";
     expect(expected).toStrictEqual(actual);
   });
 
+  it('should convert markdown to blocks - deal with images', () => {
+    const text = fs.readFileSync('test/fixtures/images.md').toString();
+    const actual = markdownToBlocks(text, false);
+
+    const expected = [
+      notion.headingOne([notion.richText('Images')]),
+      notion.paragraph([
+        notion.richText('This is an image in a paragraph '),
+        notion.richText(', which isnt supported in Notion.'),
+      ]),
+      notion.image('https://image.com/url.jpg'),
+      notion.image('https://image.com/paragraph.jpg'),
+      notion.paragraph([notion.richText('https://image.com/blah')]),
+    ];
+
+    expect(expected).toStrictEqual(actual);
+  });
+
   it('should convert markdown to rich text', () => {
     const text = 'hello [_url_](https://example.com)';
     const actual = markdownToRichText(text);

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -83,16 +83,16 @@ const hello = "hello";
     expect(expected).toStrictEqual(actual);
   });
 
-  it('should convert markdown to blocks - skip tables if unsupported = false', () => {
+  it('should convert markdown to blocks - skip tables if allowUnsupportedObjectType = false', () => {
     const text = fs.readFileSync('test/fixtures/table.md').toString();
-    const actual = markdownToBlocks(text, false);
+    const actual = markdownToBlocks(text);
     const expected = [notion.headingOne([notion.richText('Table')])];
     expect(expected).toStrictEqual(actual);
   });
 
-  it('should convert markdown to blocks - include tables if unsupported = true', () => {
+  it('should convert markdown to blocks - include tables if allowUnsupportedObjectType = true', () => {
     const text = fs.readFileSync('test/fixtures/table.md').toString();
-    const actual = markdownToBlocks(text, true);
+    const actual = markdownToBlocks(text, {allowUnsupportedObjectType: true});
     const expected = [
       notion.headingOne([notion.richText('Table')]),
       notion.table([
@@ -114,9 +114,9 @@ const hello = "hello";
     expect(expected).toStrictEqual(actual);
   });
 
-  it('should convert markdown to blocks - deal with images', () => {
+  it('should convert markdown to blocks - deal with images - strict mode', () => {
     const text = fs.readFileSync('test/fixtures/images.md').toString();
-    const actual = markdownToBlocks(text, false);
+    const actual = markdownToBlocks(text, {strictImageUrls: true});
 
     const expected = [
       notion.headingOne([notion.richText('Images')]),
@@ -127,6 +127,24 @@ const hello = "hello";
       notion.image('https://image.com/url.jpg'),
       notion.image('https://image.com/paragraph.jpg'),
       notion.paragraph([notion.richText('https://image.com/blah')]),
+    ];
+
+    expect(expected).toStrictEqual(actual);
+  });
+
+  it('should convert markdown to blocks - deal with images - not strict mode', () => {
+    const text = fs.readFileSync('test/fixtures/images.md').toString();
+    const actual = markdownToBlocks(text, {strictImageUrls: false});
+
+    const expected = [
+      notion.headingOne([notion.richText('Images')]),
+      notion.paragraph([
+        notion.richText('This is an image in a paragraph '),
+        notion.richText(', which isnt supported in Notion.'),
+      ]),
+      notion.image('https://image.com/url.jpg'),
+      notion.image('https://image.com/paragraph.jpg'),
+      notion.image('https://image.com/blah'),
     ];
 
     expect(expected).toStrictEqual(actual);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -4,6 +4,7 @@ import * as notion from '../src/notion';
 import {parseBlocks, parseRichText} from '../src/parser/internal';
 
 describe('gfm parser', () => {
+  const options = {allowUnsupportedObjectType: false, strictImageUrls: true};
   it('should parse paragraph with nested annotations', () => {
     const ast = md.root(
       md.paragraph(
@@ -14,7 +15,7 @@ describe('gfm parser', () => {
       )
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.paragraph([
@@ -48,7 +49,7 @@ describe('gfm parser', () => {
       )
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.paragraph([
@@ -74,7 +75,7 @@ describe('gfm parser', () => {
       md.paragraph(md.text('world'))
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
@@ -92,7 +93,7 @@ describe('gfm parser', () => {
       md.heading(4, md.text('heading4'))
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.headingOne([notion.richText('heading1')]),
@@ -110,7 +111,7 @@ describe('gfm parser', () => {
       md.code('public class Foo {}', 'java')
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
@@ -127,7 +128,7 @@ describe('gfm parser', () => {
       )
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.blockquote([
@@ -152,7 +153,7 @@ describe('gfm parser', () => {
       md.orderedList(md.listItem(md.paragraph(md.text('d'))))
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
@@ -189,7 +190,7 @@ describe('gfm parser', () => {
       )
     );
 
-    const actual = parseBlocks(ast);
+    const actual = parseBlocks(ast, options);
 
     const expected = [
       notion.paragraph([


### PR DESCRIPTION
- [x] Parses images that are inline
- [x] Inline images are appended after the paragraph they were inline (as notion doesn't allow images inside paragraphs)
- [x] Checks the image type against what notion allows
- [x] Defaults to the image as richText (with URL) if it is invalid as before
- [x] Options to allow for more than one
- [x] Image url parsing / validation can be disabled
- [x] Options to embed images from specific URLs
- [x] Compatible with Node 14.